### PR TITLE
Resolve Issue 95: Added SQL to prune 311 data to most recent 30 days

### DIFF
--- a/main.js
+++ b/main.js
@@ -286,7 +286,7 @@
         // TODO: would be great to prune 311 data to the last 30 days, like the police data
         "311": {
             id: "40776043-ad00-40f5-9dc8-1fde865ff571",
-            primaryFiltering: "WHERE \"NEIGHBORHOOD\" LIKE '%Oakland' ORDER BY \"CREATED_ON\" DESC",
+            primaryFiltering: "WHERE \"NEIGHBORHOOD\" LIKE '%Oakland' AND \"CREATED_ON\" >= (NOW() - '30 day'::INTERVAL) ORDER BY \"CREATED_ON\" DESC",
             latLong: ["Y", "X"],
             icon: iconTypes.CITY_311_ICON,
 
@@ -455,7 +455,7 @@
     function fetchAllData() {
         Promise.all([
             fetchWPRDCData("Police", { limit: 250 }),
-            fetchWPRDCData("311", { limit: 250 }),
+            fetchWPRDCData("311"),
             fetchWPRDCData("Arrest", { limit: 250 }),
             fetchWPRDCData("Code Violation", { limit: 250 }),
             fetchWPRDCData("Library"),


### PR DESCRIPTION
Updated the SQL query for gathering 311 data, to limit the data returned
to be from the most recent 30 days.

Also removed the arbitrary limitation that had been on the 311 data,
which limited it to gather the 250 most recent records.